### PR TITLE
Fe/discover link

### DIFF
--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -1,7 +1,7 @@
 class DiscoverController < ApplicationController
 
   def index
-    @satellites = SatelliteFacade.above_satellites(params[:lat_long])
+    @satellites = SatelliteFacade.above_satellites(params[:lat], params[:long])
   end
 
 end

--- a/app/facades/satellite_facade.rb
+++ b/app/facades/satellite_facade.rb
@@ -12,8 +12,8 @@ class SatelliteFacade
         SatelliteAPI.new(json)
     end
 
-    def self.above_satellites(lat_long)
-        json = SatelliteService.get_satellites_in_range(lat_long)[:above]
+    def self.above_satellites(lat, long)
+        json = SatelliteService.get_satellites_in_range(lat, long)[:above]
         json[0..9].map do |data|
             DiscoverSatellite.new(data)
         end

--- a/app/services/satellite_service.rb
+++ b/app/services/satellite_service.rb
@@ -10,8 +10,8 @@ class SatelliteService
         BaseService.get_json(response)
     end
 
-    def self.get_satellites_in_range(lat_long)
-        response = BaseService.n2yo_connection.get("/rest/v1/satellite/above/#{lat_long[0]}/#{lat_long[1]}/0/15/0/")
+    def self.get_satellites_in_range(lat, long)
+        response = BaseService.n2yo_connection.get("/rest/v1/satellite/above/#{lat}/#{long}/0/15/0/")
         JSON.parse(response.body, symbolize_names: true)
     end
 

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -3,5 +3,6 @@
 <div id="satellites<%= index %>">
 <p>Name: <%= satellite.satname %> ID: <%= satellite.satid %><p><br>
 <p>Launched on: <%= satellite.launch_date %><p><br>
+<p><%= link_to, 'View Satellite Info', api_v1_satellite_path(satellite.satid) %><p><br>
 </div>
 <% end %>

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -3,6 +3,6 @@
 <div id="satellites<%= index %>">
 <p>Name: <%= satellite.satname %> ID: <%= satellite.satid %><p><br>
 <p>Launched on: <%= satellite.launch_date %><p><br>
-<p><%= link_to, 'View Satellite Info', api_v1_satellite_path(satellite.satid) %><p><br>
+<p><%= link_to 'View Satellite Info', api_v1_satellite_path(satellite.satid) %><p><br>
 </div>
 <% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,3 +2,4 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
 end
 OmniAuth.config.allowed_request_methods = %i[get]
+OmniAuth.config.silence_get_warning = true

--- a/spec/facades/satellite_facade_spec.rb
+++ b/spec/facades/satellite_facade_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe SatelliteFacade do
 
       allow(SatelliteService).to receive(:get_satellites_in_range).and_return(@found_satellites)
 
-      lat_long = [39.6431, -104.8987]
-      results = SatelliteFacade.above_satellites(lat_long)
+      results = SatelliteFacade.above_satellites(39.6431, -104.8987)
       
       expect(results.count).to eq(10)
     end
@@ -27,4 +26,5 @@ RSpec.describe SatelliteFacade do
         expect(satellites).to be_a(Array)
         expect(satellites).to be_all(Satellite)
     end
+  end
 end

--- a/spec/features/discover/discover_spec.rb
+++ b/spec/features/discover/discover_spec.rb
@@ -16,11 +16,7 @@ RSpec.describe 'Discover page' do
         "token" => "Token",
         },
     })
-    
-    remote_ip = '161.185.160.93'
 
-    lat_long = [39.6431, -104.8987]
-          
     @satellites = JSON.parse(File.read('spec/fixtures/satellites.json'), symbolize_names: true)
     @visible_sat_times = JSON.parse(File.read('spec/fixtures/satellite_visibility.json'), symbolize_names: true)
     @weather_data = JSON.parse(File.read('spec/fixtures/weather_data.json'), symbolize_names: true)
@@ -43,7 +39,6 @@ RSpec.describe 'Discover page' do
     end
 
     it 'should display max ten satellites in range of user' do
-
       visit discover_users_path
 
       within '#satellites0' do
@@ -71,7 +66,7 @@ RSpec.describe 'Discover page' do
 
         click_link('View Satellite Info')
       end
-      
+
       expect(current_path).to eq(api_v1_satellite_path(satellite.satid))
       expect(page).to have_content("DELTA 1 DEB's Show")
     end

--- a/spec/features/discover/discover_spec.rb
+++ b/spec/features/discover/discover_spec.rb
@@ -60,20 +60,20 @@ RSpec.describe 'Discover page' do
 
   describe '#link_satellite_show' do
     it 'Below the satellite Name and ID is a link to the satellite show page' do
-      satellite = DiscoverSatellite.new(satid: 2435, satname: 'ESSA 3 (TOS-A)', launch_date: '1965-11-06')
+      satellite = DiscoverSatellite.new(satid: 2700, satname: 'DELTA 1 DEB', launch_date: '1965-11-06')
 
       visit discover_users_path
 
-      within '#satellites0' do
+      within '#satellites1' do
 
-        expect(page).to have_content("Name: ESSA 3 (TOS-A) ID: 2435")
-        expect(page).to have_link(" View Satellite Info")
+        expect(page).to have_content("Name: DELTA 1 DEB ID: 2700")
+        expect(page).to have_link("View Satellite Info")
 
         click_link('View Satellite Info')
-
-        expect(current_path).to eq(api_v1_satellite_path(satellite.satid))
-        expect(page).to have_content("ESSA 3 (TOS-A)'s Show")
       end
+      
+      expect(current_path).to eq(api_v1_satellite_path(satellite.satid))
+      expect(page).to have_content("DELTA 1 DEB's Show")
     end
   end
 end

--- a/spec/features/discover/discover_spec.rb
+++ b/spec/features/discover/discover_spec.rb
@@ -57,4 +57,23 @@ RSpec.describe 'Discover page' do
       end
     end
   end
+
+  describe '#link_satellite_show' do
+    it 'Below the satellite Name and ID is a link to the satellite show page' do
+      satellite = DiscoverSatellite.new(satid: 2435, satname: 'ESSA 3 (TOS-A)', launch_date: '1965-11-06')
+
+      visit discover_users_path
+
+      within '#satellites0' do
+
+        expect(page).to have_content("Name: ESSA 3 (TOS-A) ID: 2435")
+        expect(page).to have_link(" View Satellite Info")
+
+        click_link('View Satellite Info')
+
+        expect(current_path).to eq(api_v1_satellite_path(satellite.satid))
+        expect(page).to have_content("ESSA 3 (TOS-A)'s Show")
+      end
+    end
+  end
 end

--- a/spec/service/satellite_service_spec.rb
+++ b/spec/service/satellite_service_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe SatelliteService do
       @found_satellites = JSON.parse(File.read('spec/fixtures/above_satellites.json'), symbolize_names: true)
 
       allow(SatelliteService).to receive(:get_satellites_in_range).and_return(@found_satellites)
-
-      lat_long = [39.6431, -104.8987]
-      ss = SatelliteService.get_satellites_in_range(lat_long)
+      
+      ss = SatelliteService.get_satellites_in_range(39.6431, -104.8987)
       sr = ss[:above].first
 
       expect(ss).to be_a(Hash)


### PR DESCRIPTION
**Link from Discover page to Satellite show page**

**Introduces:**
- Add: Link called View Satellite info under each satellite that is returned above the user to redirect to the satellite show page
- Add: OmniAuth.config silence warning to OmniAuth initializer to speed up test suite
-  All tests passed. 

- Refactor: 
- Add: Refactor above API call tests to integrate new application controller helper methods
- N/A


<br>

**Testing Changes:**

   - [ ] No Tests have been changed
   - [x] Some Tests have been changed. Please describe which ones:  Refactored above service call tests
   - [ ] All of the Tests have been changed. Please describe what in the world happened:

<br>

**Testing Functionality:**
   - [x] All Tests are Passing
   - [ ] Some Tests are not passing. Please describe which ones:
   - [ ] All Postman Tests are Passing
   - [ ] Some Postman Tests produce errors. Please describe which ones:
   - [x] Coverage report generated. Please report RSpec coverage: x / x LOC (97.29%) covered.

<br>

**Feature Functionality:**
   - [x] The code will run locally
   - [ ] The code will not run locally. Please describe what features:
   - [ ] The code will run on Heroku
   - [ ] The code will not run on Heroku. Please describe what features: 
   - [ ] Circle CI is fully functional.
   - [ ] Circle CI is not fully functional. Please describe which parts: 



<br>

**Add any optional / additional extended information:**
